### PR TITLE
Various fixes

### DIFF
--- a/examples/magnum.pp
+++ b/examples/magnum.pp
@@ -1,0 +1,60 @@
+# An example compatible with https://github.com/openstack/puppet-openstack-integration approach
+# Works on Mitaka release
+# Tested on RDO/CentOS 7 and Puppet 3.8.7
+#
+
+  include ::openstack_integration::config
+  include ::openstack_integration::params
+
+  rabbitmq_user { 'magnum':
+    admin    => true,
+    password => 'an_even_bigger_secret',
+    provider => 'rabbitmqctl',
+    require  => Class['::rabbitmq'],
+  }
+
+  rabbitmq_user_permissions { 'magnum@/':
+    configure_permission => '.*',
+    write_permission     => '.*',
+    read_permission      => '.*',
+    provider             => 'rabbitmqctl',
+    require              => Class['::rabbitmq'],
+  }
+
+  class { '::magnum::db::mysql':
+    password => 'magnum',
+  }
+
+  class { '::magnum::db':
+    database_connection => 'mysql://magnum:magnum@127.0.0.1/magnum',
+  }
+
+  class { '::magnum::api':
+    admin_password => 'a_big_secret',
+    auth_uri       => $::openstack_integration::config::keystone_auth_uri,
+    identity_uri   => $::openstack_integration::config::keystone_admin_uri,
+    host           => $::openstack_integration::config::ip_for_url,
+    auth_version   => 'v3',
+  }
+
+  class { '::magnum::keystone::auth':
+    password     => 'a_big_secret',
+    public_url   => "http://${::openstack_integration::config::ip_for_url}:9511/v1",
+    internal_url => "http://${::openstack_integration::config::ip_for_url}:9511/v1",
+    admin_url    => "http://${::openstack_integration::config::ip_for_url}:9511/v1",
+  }
+
+  class { '::magnum':
+    rabbit_host         => $::openstack_integration::config::ip_for_url,
+    rabbit_port         => $::openstack_integration::config::rabbit_port,
+    rabbit_userid       => 'magnum',
+    rabbit_password     => 'an_even_bigger_secret',
+    rabbit_use_ssl      => $::openstack_integration::config::ssl,
+    notification_driver => 'messagingv2',
+  }
+
+  class { '::magnum::conductor':
+  }
+
+  class { '::magnum::client':
+  }

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -19,7 +19,7 @@
 #  (Optional) The port for the Magnum API server.
 #  Defaults to '9511'
 #
-# [*host_ip*]
+# [*host*]
 #  (Optional) The listen IP for the Magnum API server.
 #  Defaults to '127.0.0.1'
 #
@@ -41,6 +41,10 @@
 #  use 'v3' for the keystone version 3 API.
 #  Defaults to false
 #
+# [*sync_db*]
+#  (Optional) Enable DB sync
+#  Defaults to true
+#
 # [*admin_tenant_name*]
 #  (Optional) The name of the tenant to create in keystone for use by Magnum services.
 #  Defaults to 'services'
@@ -55,11 +59,12 @@ class magnum::api(
   $package_ensure    = 'present',
   $enabled           = true,
   $port              = '9511',
-  $host_ip           = '127.0.0.1',
+  $host              = '127.0.0.1',
   $max_limit         = '1000',
   $auth_uri          = 'http://localhost:5000/',
   $identity_uri      = 'http://localhost:35357/',
   $auth_version      = false,
+  $sync_db           = true,
   $admin_tenant_name = 'services',
   $admin_user        = 'magnum',
 ) {
@@ -67,13 +72,17 @@ class magnum::api(
   include ::magnum::params
   include ::magnum::policy
 
+  if $sync_db {
+    include ::magnum::db::sync
+  }
+
   Magnum_config<||> ~> Service['magnum-api']
   Class['magnum::policy'] ~> Service['magnum-api']
 
   # Configure API conf
   magnum_config {
     'api/port' :      value => $port;
-    'api/host_ip' :   value => $host_ip;
+    'api/host' :      value => $host;
     'api/max_limit' : value => $max_limit;
   }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,0 +1,23 @@
+# == Class: magnum::client
+#
+# Manages the magnum client package on systems
+#
+# === Parameters:
+#
+# [*package_ensure*]
+#   (optional) The state of the package
+#   Defaults to present
+#
+class magnum::client (
+  $package_ensure = present
+) {
+
+  include ::magnum::params
+
+  package { 'python2-magnumclient':
+    ensure => $package_ensure,
+    name   => $::magnum::params::client_package,
+    tag    => 'openstack',
+  }
+
+}

--- a/manifests/conductor.pp
+++ b/manifests/conductor.pp
@@ -53,7 +53,7 @@ class magnum::conductor(
     name      => $::magnum::params::conductor_package,
     enable    => $enabled,
     hasstatus => true,
-    tag       => 'magnum-service',
+    tag       => ['magnum-service', 'magnum-db-sync-service'],
   }
 
   magnum_config {

--- a/manifests/db/sync.pp
+++ b/manifests/db/sync.pp
@@ -14,10 +14,10 @@
 #
 class magnum::db::sync(
   $user         = 'magnum',
-  $extra_params = undef,
+  $extra_params = '--config-file /etc/magnum/magnum.conf',
 ) {
   exec { 'magnum-db-sync':
-    command     => "magnum-db-manage upgrade ${extra_params}",
+    command     => "magnum-db-manage ${extra_params} upgrade head",
     path        => '/usr/bin',
     user        => $user,
     refreshonly => true,
@@ -27,4 +27,5 @@ class magnum::db::sync(
   Package<| tag == 'magnum-package' |> ~> Exec['magnum-db-sync']
   Exec['magnum-db-sync'] ~> Service<| tag == 'magnum-db-sync-service' |>
   Magnum_config<| title == 'database/connection' |> ~> Exec['magnum-db-sync']
+  Magnum_config <| |> ~> Exec['magnum-db-sync']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,7 @@ class magnum(
 
   magnum_config {
     'DEFAULT/rpc_backend' :                        value => 'rabbit';
-    'oslo_messaging_rabbit/userid' :               value => $rabbit_userid;
+    'oslo_messaging_rabbit/rabbit_userid' :        value => $rabbit_userid;
     'oslo_messaging_rabbit/rabbit_password' :      value => $rabbit_password, secret => true;
     'oslo_messaging_rabbit/rabbit_virtual_host' :  value => $rabbit_virtual_host;
     'oslo_messaging_rabbit/rabbit_use_ssl' :       value => $rabbit_use_ssl;

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class magnum::params {
       # service names
       $api_service            = 'openstack-magnum-api'
       $conductor_service      = 'openstack-magnum-conductor'
+      $client_package         = 'python2-magnumclient'
     }
     'Debian': {
       # package names
@@ -20,6 +21,7 @@ class magnum::params {
       # service names
       $api_service            = 'magnum-api'
       $conductor_service      = 'magnum-conductor'
+      $client_package         = 'python-magnumclient'
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily} operatingsystem")

--- a/spec/acceptance/nodesets/centos-72-x64.yml
+++ b/spec/acceptance/nodesets/centos-72-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-server-72-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.2-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/centos-7.2-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/classes/magnum_api_spec.rb
+++ b/spec/classes/magnum_api_spec.rb
@@ -9,10 +9,11 @@ describe 'magnum::api' do
     { :package_ensure    => 'present',
       :enabled           => true,
       :port              => '9511',
-      :host_ip           => '127.0.0.1',
+      :host              => '127.0.0.1',
       :max_limit         => '1000',
       :auth_uri          => 'http://localhost:5000/',
       :identity_uri      => 'http://localhost:35357/',
+      :sync_db           => 'true',
       :admin_tenant_name => 'services',
       :admin_user        => 'magnum',
     }
@@ -50,7 +51,7 @@ describe 'magnum::api' do
 
     it 'configures magnum.conf' do
       is_expected.to contain_magnum_config('api/port').with_value(p[:port])
-      is_expected.to contain_magnum_config('api/host_ip').with_value(p[:host_ip])
+      is_expected.to contain_magnum_config('api/host').with_value(p[:host])
       is_expected.to contain_magnum_config('api/max_limit').with_value(p[:max_limit])
       is_expected.to contain_magnum_config('keystone_authtoken/admin_password').with_value(p[:admin_password]).with_secret(true)
       is_expected.to contain_magnum_config('keystone_authtoken/admin_user').with_value(p[:admin_user])
@@ -62,17 +63,17 @@ describe 'magnum::api' do
     context 'when overriding parameters' do
       before :each do
         params.merge!(
-          :port    => '1234',
-          :host_ip => '0.0.0.0',
-          :max_limit => '10',
-          :auth_uri => 'http://10.0.0.1:5000/',
+          :port         => '1234',
+          :host         => '0.0.0.0',
+          :max_limit    => '10',
+          :auth_uri     => 'http://10.0.0.1:5000/',
           :identity_uri => 'http://10.0.0.1:35357/',
         )
       end
 
       it 'should replace default parameters with new values' do
         is_expected.to contain_magnum_config('api/port').with_value(p[:port])
-        is_expected.to contain_magnum_config('api/host_ip').with_value(p[:host_ip])
+        is_expected.to contain_magnum_config('api/host').with_value(p[:host])
         is_expected.to contain_magnum_config('api/max_limit').with_value(p[:max_limit])
         is_expected.to contain_magnum_config('keystone_authtoken/admin_password').with_value(p[:admin_password]).with_secret(true)
         is_expected.to contain_magnum_config('keystone_authtoken/admin_user').with_value(p[:admin_user])

--- a/spec/classes/magnum_db_sync_spec.rb
+++ b/spec/classes/magnum_db_sync_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'magnum::db::sync' do
+
+  shared_examples_for 'magnum-dbsync' do
+
+    it 'runs magnum-db-sync' do
+      is_expected.to contain_exec('magnum-db-sync').with(
+        :command     => 'magnum-db-manage --config-file /etc/magnum/magnum.conf upgrade head',
+        :path        => '/usr/bin',
+        :refreshonly => 'true',
+        :logoutput   => 'on_failure'
+      )
+    end
+
+    describe "overriding extra_params" do
+    let :params do
+      {
+        :extra_params => '--config-file /etc/magnum/magnum.conf',
+      }
+    end
+
+    it {
+        is_expected.to contain_exec('magnum-db-sync').with(
+          :command     => 'magnum-db-manage --config-file /etc/magnum/magnum.conf upgrade head',
+          :path        => '/usr/bin',
+          :refreshonly => 'true',
+          :logoutput   => 'on_failure'
+        )
+    }
+    end
+
+  end
+
+  on_supported_os({
+    :supported_os   => OSDefaults.get_supported_os
+  }).each do |os,facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge!(OSDefaults.get_facts())
+      end
+    
+      it_configures 'magnum-dbsync'
+    end
+
+  end
+
+end

--- a/spec/classes/magnum_init_spec.rb
+++ b/spec/classes/magnum_init_spec.rb
@@ -44,12 +44,12 @@ describe 'magnum' do
 
     context 'with overridden parameters' do
       let :params do
-        { :package_ensure => 'latest',
+        { :package_ensure      => 'latest',
           :notification_driver => 'messagingv1',
-          :rabbit_host => '53.210.103.65',
-          :rabbit_port => '1234',
-          :rabbit_userid => 'me',
-          :rabbit_password => 'secrete',
+          :rabbit_host         => '53.210.103.65',
+          :rabbit_port         => '1234',
+          :rabbit_userid       => 'me',
+          :rabbit_password     => 'secrete',
           :rabbit_virtual_host => 'vhost',
         }
       end
@@ -101,12 +101,12 @@ describe 'magnum' do
 
     context 'with rabbit ssl enabled with kombu' do
       let :params do
-        { :rabbit_hosts => ['rabbit:5673'],
-          :rabbit_use_ssl => true,
+        { :rabbit_hosts       => ['rabbit:5673'],
+          :rabbit_use_ssl     => true,
           :kombu_ssl_ca_certs => '/etc/ca.crt',
           :kombu_ssl_certfile => '/etc/certfile',
-          :kombu_ssl_keyfile => '/etc/key',
-          :kombu_ssl_version => 'TLSv1',
+          :kombu_ssl_keyfile  => '/etc/key',
+          :kombu_ssl_version  => 'TLSv1',
         }
       end
 


### PR DESCRIPTION
- correcting "host_ip" entry to be "host" entry for magnum.conf
- correcting "userid" to be "rabbit_userid" entry inside magnum.conf
- db sync function
- beaker tests are working on Ubuntu as well.
- Update metadata.json with new openstacklib version.

Adding:
- client class with client package installation
- examples folder with example which works with Mitaka release
- spec for db_sync
- adding nodesets spec for CentOS 7.2

Change-Id: Ib923f79da691b5c71bb1c4efba8935c774598888
